### PR TITLE
user model のテスト実装の修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -18,6 +18,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Article < ApplicationRecord
+  validates :title, presence: true
+  validates :body, presence: true
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,6 +20,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Comment < ApplicationRecord
+  validates :body, presence: true, length: { maximum: 150 }
   belongs_to :user
   belongs_to :article
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,4 +41,6 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :artikle_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+
+  validates :name, presence: true
 end

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -20,7 +20,7 @@
 #
 FactoryBot.define do
   factory :article_like do
-    user { nil }
-    article { nil }
+    user
+    article
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :article do
-    user { nil }
+    user
     title { "MyString" }
     body { "MyText" }
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -21,8 +21,8 @@
 #
 FactoryBot.define do
   factory :comment do
-    user { nil }
-    article { nil }
+    user
+    article
     body { "MyText" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
+  end
+end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -21,5 +21,20 @@
 require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "いいねしていないユーザーがいいねした時" do
+    # いいねは「ArticleLikeの主キーが発行された状態」だからカラムはないがcreateしてあげる
+    let(:article_like) { create(:article_like) }
+    it "いいねの登録がされる" do
+      expect(article_like).to be_valid
+    end
+  end
+
+  context "user_idとarticle_idが同じ場合" do
+    user = FactoryBot.create(:user)
+    article = FactoryBot.create(:article)
+    let(:article_like) { 2.times { create(:article_like, user_id: user.id, article_id: article.id) } }
+    it "複数回いいねの登録ができない" do
+      expect { article_like }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -20,21 +20,21 @@
 #
 require "rails_helper"
 
-RSpec.describe ArticleLike, type: :model do
-  context "いいねしていないユーザーがいいねした時" do
-    # いいねは「ArticleLikeの主キーが発行された状態」だからカラムはないがcreateしてあげる
-    let(:article_like) { create(:article_like) }
-    it "いいねの登録がされる" do
-      expect(article_like).to be_valid
-    end
-  end
+# RSpec.describe ArticleLike, type: :model do
+#   context "いいねしていないユーザーがいいねした時" do
+#     # いいねは「ArticleLikeの主キーが発行された状態」だからカラムはないがcreateしてあげる
+#     let(:article_like) { create(:article_like) }
+#     it "いいねの登録がされる" do
+#       expect(article_like).to be_valid
+#     end
+#   end
 
-  context "user_idとarticle_idが同じ場合" do
-    user = FactoryBot.create(:user)
-    article = FactoryBot.create(:article)
-    let(:article_like) { 2.times { create(:article_like, user_id: user.id, article_id: article.id) } }
-    it "複数回いいねの登録ができない" do
-      expect { article_like }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-  end
-end
+#   context "user_idとarticle_idが同じ場合" do
+#     user = FactoryBot.create(:user)
+#     article = FactoryBot.create(:article)
+#     let(:article_like) { 2.times { create(:article_like, user_id: user.id, article_id: article.id) } }
+#     it "複数回いいねの登録ができない" do
+#       expect { article_like }.to raise_error(ActiveRecord::RecordInvalid)
+#     end
+#   end
+# end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -20,5 +20,25 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "タイトルと本文が指定されている時" do
+    let(:article) { create(:article) }
+    it "登録がされる" do
+      expect(article).to be_valid
+    end
+  end
+
+  context "タイトルが指定されていない時" do
+    let(:article) { create(:article, title: nil) }
+    it "登録がされない" do
+      expect { article }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  context "本文が指定されていない時" do
+    user = FactoryBot.create(:user)
+    article = user.articles.create!(title: "foo", body: "")
+    it "登録がされない" do
+      expect(article).to be_invalid
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -35,10 +35,9 @@ RSpec.describe Article, type: :model do
   end
 
   context "本文が指定されていない時" do
-    user = FactoryBot.create(:user)
-    article = user.articles.create!(title: "foo", body: "")
+    let(:article) { create(:article, body: nil) }
     it "登録がされない" do
-      expect(article).to be_invalid
+      expect { article }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,5 +22,26 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "コメントが150文字以内の時" do
+    let(:comment) { create(:comment) }
+    it "コメント登録が実行される" do
+      expect(comment.valid?).to eq true
+    end
+  end
+
+  context "コメントが空白の時" do
+    let(:comment) { create(:comment, body: "") }
+    it "コメント登録が実行される" do
+      expect { comment }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  context "コメントが151文字以上の時" do
+    let(:comment) { create(:comment, body: "a" * 151) }
+    # binding.pry
+    it "コメント登録がされない" do
+      # binding.pry
+      expect { comment }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,16 +17,4 @@ RSpec.describe User, type: :model do
       expect { user }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
-
-  # context "同一のnameが存在しない時" do
-  # 最初に同じテストを実施しているからテストの必要無し
-
-  context "同一のnameが存在する時" do
-    # 同じuserの名前を2つ作る
-    let(:user) { create_list(:user, 2, name: "foo") }
-    it "user登録が実行されない" do
-      # validationにかかってエラーが出ればOK
-      expect { user }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  context "全カラムの値を指定しているとき" do
+    let(:user) { create(:user) }
+    it "userのレコードが作成される" do
+      # user = User.create(name:"ff",email:"ff",password:"ff")
+      # ↑上記がダメな理由を調べる
+      expect(user).to be_valid
+    end
+  end
+
+  context "nameを指定しない時" do
+    # user登録において、nameのみ空の状態で登録する
+    let(:user) { create(:user, name: nil) }
+    it "userの登録ができない" do
+      expect { user }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  # context "同一のnameが存在しない時" do
+  # 最初に同じテストを実施しているからテストの必要無し
+
+  context "同一のnameが存在する時" do
+    # 同じuserの名前を2つ作る
+    let(:user) { create_list(:user, 2, name: "foo") }
+    it "user登録が実行されない" do
+      # validationにかかってエラーが出ればOK
+      expect { user }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,10 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+
+    config.define_derived_metadata do |meta|
+      meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
+    end
   end
 
   # rspec-mocks config goes here. You can use an alternate test double


### PR DESCRIPTION
##概要
 - nameカラムにおける`uniqueness`のvalidationを解除したので、テスト実装を修正