### PR TITLE
新規登録 API の実装とテスト実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,4 +7,4 @@ inherit_from:
   - config/rubocop/rspec.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -34,13 +34,13 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "factory_bot_rails"
   gem "faker"
+  gem "foreman" # 追加
   gem "pry-byebug" # 追加
   gem "pry-doc" # 追加
   gem "pry-rails" # 追加
   gem "rspec-rails"
   gem "rubocop-rails" # 追加
   gem "rubocop-rspec" # 追加
-  gem "foreman" #追加
 end
 
 group :development do

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def account_update_params
+      params.permit(:name, :email)
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module WonderfulEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
       resources :articles
+      mount_devise_token_auth_for "User", at: "auth", controllers: { registrations: "api/v1/auth/registrations" }
     end
   end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "適切なパラメーターを送信した時" do
+      let(:params) { attributes_for(:user) }
+      it "レコードが発行される" do
+        expect { subject }.to change { User.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
+        expect(res["data"]["id"]).to eq User.last.id
+        expect(res["data"]["name"]).to eq User.last.name
+        expect(res["data"]["email"]).to eq User.last.email
+      end
+
+      it "適切にheader情報が返ってくる" do
+        subject
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
+        binding.pry
+      end
+    end
+
+    context "nameが存在しない時" do
+      let(:params) { attributes_for(:user, name: nil) }
+
+      it "レコードが発行されない" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "error"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "emailが存在しない時" do
+      let(:params) { attributes_for(:user, email: nil) }
+
+      it "レコードが発行されない" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "error"
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["email"]).to eq ["can't be blank"]
+      end
+    end
+
+    context "password が存在しない時" do
+      let(:params) { attributes_for(:user, password: nil) }
+
+      it "レコードが発行されない" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "error"
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["password"]).to include "can't be blank"
+      end
+    end
+  end
+end


### PR DESCRIPTION
##概要
 - `registrations_controller.rb` を作成
 - `registrations_spec.rb` を作成してテスト実装
 - `devise_token_auth.rb` の一部をコメントアウト