### PR TITLE
api_controller のダミーコードである current_user メソッド を削除

### DIFF
--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,12 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
+  before_action :authenticate_user!, except: [:index, :show]
+  def index
   end
+
+  def show
+  end
+
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,25 +1,25 @@
 require "rails_helper"
 
 RSpec.describe "Articles", type: :request do
-  # describe "GET /api/v1/articles" do
-  #   subject { get(api_v1_articles_path) }
+  describe "GET /api/v1/articles" do
+    subject { get(api_v1_articles_path) }
 
-  #   context "記事のレコードが発行された場合" do
-
-  #     let!(:article1) { create(:article, updated_at: 1.days.ago) }
-  #     let!(:article){create(:article)}
-  #     let!(:article2) { create(:article, updated_at: 2.days.ago) }
-  #     fit "記事一覧を取得できる" do
-  #       subject
-  #       res = JSON.parse(response.body)
-  #       a = Article.all.order(updated_at: "DESC")
-  #       expect(res.count).to eq 3
-  #       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"] # 記事にbodyが含まれていない&更新日が表示
-  #       expect(response).to have_http_status(:ok) # 誰でも見れる
-  #       expect(a.map {|article_| article_.id }).to eq [article.id, article1.id, article2.id] # idを古い順にならびかえることで更新順かどうかわかる。
-  #     end
-  #   end
-  # end
+    context "記事のレコードが発行された場合" do
+      let!(:article1) { create(:article, updated_at: 1.days.ago) }
+      let!(:article) { create(:article) }
+      let!(:article2) { create(:article, updated_at: 2.days.ago) }
+      it "記事一覧を取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        # a = Article.all.order(updated_at: "DESC")
+        expect(res.count).to eq 3
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"] # 記事にbodyが含まれていない&更新日が表示
+        expect(response).to have_http_status(:ok) # 誰でも見れる
+        expect(res.map {|d| d["id"] }).to eq [article.id, article1.id, article2.id]
+        # expect(a.map {|article_| article_.id }).to eq [article.id, article1.id, article2.id] idを古い順にならびかえることで更新順かどうかわかる。
+      end
+    end
+  end
 
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
@@ -52,13 +52,13 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "適切なパラメーターを送信した時" do
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-
       let(:current_user) { create(:user) }
       let(:params) { { article: attributes_for(:article) } }
+      let(:headers) { current_user.create_new_auth_token }
+
       it "レコードが発行される" do
         expect { subject }.to change { Article.count }.by(1)
         res = JSON.parse(response.body)
@@ -72,10 +72,10 @@ RSpec.describe "Articles", type: :request do
     end
 
     context "不適切なパラメータを送信した時" do
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-
       let(:current_user) { create(:user) }
       let(:params) { attributes_for(:article) }
+      let(:headers) { current_user.create_new_auth_token }
+
       it "レコードが発行されない" do
         expect { subject }.to raise_error(ActionController::ParameterMissing)
       end
@@ -83,20 +83,19 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "PATCH(PUT) /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article_id), params: params) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     let(:current_user) { create(:user) }
     let(:params) { { article: { title: "aaa", created_at: 1.day.ago } } }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "適切なパラメータを送信した時" do
       let(:article_id) { article.id }
       let(:article) { create(:article, user_id: current_user.id) }
       it "指定した内容だけレコードが更新される" do
-        expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title]) &
-                              not_change { Article.find(article_id).body } &
-                              not_change { Article.find(article_id).created_at }
+        expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title])
+        not_change { Article.find(article_id).body }
+        not_change { Article.find(article_id).created_at }
         expect(response).to have_http_status(:ok)
       end
     end
@@ -112,12 +111,11 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "対象のレコードを削除しようとした時" do
       let!(:article) { create(:article, user: current_user) }


### PR DESCRIPTION
##概要
 - ダミーコードの current_user メソッド を削除
 -  devise_token_auth で提供されている current_user メソッド を実装