### PR TITLE
enum を使って下書き記事、公開記事の保存のテスト実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -23,4 +24,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+
+  enum status: { draft: 0, publishe: 1 }
 end

--- a/db/migrate/20220919031620_add_status_to_articles.rb
+++ b/db/migrate/20220919031620_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_31_070703) do
+ActiveRecord::Schema.define(version: 2022_09_19_031620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2022_08_31_070703) do
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -22,5 +23,13 @@ FactoryBot.define do
     user
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
+
+    trait :draft do
+      status { 0 }
+    end
+
+    trait :publishe do
+      status { 1 }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     name { Faker::Name.name }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -38,6 +39,35 @@ RSpec.describe Article, type: :model do
     let(:article) { create(:article, body: nil) }
     it "登録がされない" do
       expect { article }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe "正常系" do
+    context "タイトルと本文が入力されているとき" do
+      let(:article) { build(:article) }
+
+      it "下書き状態の記事が作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が下書き状態のとき" do
+      let(:article) { build(:article, :draft) }
+
+      it "下書き状態の記事が作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が公開状態のとき" do
+      let(:article) { build(:article, :publishe) }
+
+      it "公開状態の記事が作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "publishe"
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe User, type: :model do


### PR DESCRIPTION
##概要
 - `rails g migration AddStatusToArticles status:intege`r コマンドを実行
 - 下書き記事と公開記事の保存のテスト実装を行う