### PR TITLE
マイページで自分の公開記事のみ閲覧できるように実装

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Current::ArticlesController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.publishe.order(updated_at: "DESC")
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+      namespace :current do
+        resources :articles, only: [:index]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "自分の公開記事が作成された時" do
+      let!(:article) { create(:article, :publishe, user: current_user) }
+      let!(:article1) { create(:article, :publishe, updated_at: 1.days.ago, user: current_user) }
+      let!(:article2) { create(:article, :publishe) }
+
+      before do
+        create(:article, :draft, user: current_user)
+      end
+
+      fit "自分の公開記事一覧が取得できる" do
+        subject
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
+        expect(res.count).to eq 2
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
+        expect(res.map {|d| d["id"] }).to eq [article.id, article1.id]
+      end
+    end
+  end
+end


### PR DESCRIPTION
##概要
 - マイページ専用の `articles_controller.rb` を作成
 - `articles_spec.rb`を作成
 - ルーティングの修正を行う