### PR TITLE
heroku の 「Application error」エラー解消を試みるため、procfile を削除

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
-webpacker: ./bin/webpack-dev-server


### PR DESCRIPTION
##概要
 - タイトルの通り