### PR TITLE
auto_annote_models.rake の記述を一部修正

### DIFF
--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -3,7 +3,7 @@
 # NOTE: to have a dev-mode tool do its thing in production.
 if Rails.env.development?
   require "annotate"
-  task :set_annotation_options => environment do
+  task set_annotation_options: :environment do
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(


### PR DESCRIPTION
## 概要
 - rubocop でのエラー対応のために記述を修正